### PR TITLE
[Demo invite] Add patch method for Engagement

### DIFF
--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -35,20 +35,6 @@ module Hubspot
         handle_response(response)
       end
 
-      def patch_json(path, options)
-        url = generate_url(path, options[:params])
-
-        response = patch(
-          url,
-          body: options[:body].to_json,
-          headers: { "Content-Type" => "application/json" },
-          format: :json
-        )
-
-        log_request_and_response(url, response, options[:body])
-        handle_response(response)
-      end
-
       def delete_json(path, opts)
         url = generate_url(path, opts)
         response = delete(url, format: :json)

--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -35,6 +35,20 @@ module Hubspot
         handle_response(response)
       end
 
+      def patch_json(path, options)
+        url = generate_url(path, options[:params])
+
+        response = patch(
+          url,
+          body: options[:body].to_json,
+          headers: { "Content-Type" => "application/json" },
+          format: :json
+        )
+
+        log_request_and_response(url, response, options[:body])
+        handle_response(response)
+      end
+
       def delete_json(path, opts)
         url = generate_url(path, opts)
         response = delete(url, format: :json)

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -126,7 +126,7 @@ module Hubspot
         metadata: params[:metadata]         || metadata
       }
 
-      Hubspot::Connection.patch_json(ENGAGEMENT_PATH, params: { engagement_id: id }, body: data)
+      Hubspot::Connection.put_json(ENGAGEMENT_PATH, params: { engagement_id: id }, body: data)
       self
     end
   end

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -126,7 +126,7 @@ module Hubspot
         metadata: params[:metadata]         || metadata
       }
 
-      Hubspot::Connection.put_json(ENGAGEMENT_PATH, params: { engagement_id: id }, body: data)
+      Hubspot::Connection.patch_json(ENGAGEMENT_PATH, params: { engagement_id: id }, body: data)
       self
     end
   end


### PR DESCRIPTION
notion card: [https://www.notion.so/matera/2-BACK-Email-sending-after-lead-s-form-submission-b2802adc864f4f3d9d58ccc00def12d4](url)
this method was not up to date to call the Hubspot API Platform